### PR TITLE
Reduce use of snprintf and fixed-size buffers

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -5896,8 +5896,8 @@ Status DBImpl::IngestExternalFiles(
   const size_t num_cfs = args.size();
   for (size_t i = 0; i != num_cfs; ++i) {
     if (args[i].external_files.empty()) {
-      char err_msg[128] = {0};
-      snprintf(err_msg, 128, "external_files[%zu] is empty", i);
+      std::string err_msg =
+          "external_files[" + std::to_string(i) + "] is empty";
       return Status::InvalidArgument(err_msg);
     }
     if (i && args[i].options.fill_cache != args[i - 1].options.fill_cache) {

--- a/db/dbformat.cc
+++ b/db/dbformat.cc
@@ -178,11 +178,9 @@ std::string ParsedInternalKey::DebugString(bool log_err_key, bool hex,
     result += "<redacted>";
   }
 
-  char buf[50];
-  snprintf(buf, sizeof(buf), "' seq:%" PRIu64 ", type:%d", sequence,
-           static_cast<int>(type));
+  result += "' seq:" + std::to_string(sequence);
+  result += ", type:" + std::to_string(type);
 
-  result += buf;
   return result;
 }
 

--- a/db/internal_stats.cc
+++ b/db/internal_stats.cc
@@ -13,6 +13,7 @@
 #include <algorithm>
 #include <cinttypes>
 #include <cstddef>
+#include <iomanip>
 #include <limits>
 #include <sstream>
 #include <string>
@@ -89,35 +90,44 @@ const double kMB = 1048576.0;
 const double kGB = kMB * 1024;
 const double kMicrosInSec = 1000000.0;
 
-void PrintLevelStatsHeader(char* buf, size_t len, const std::string& cf_name,
+void PrintLevelStatsHeader(std::ostringstream& oss, const std::string& cf_name,
                            const std::string& group_by) {
-  int written_size =
-      snprintf(buf, len, "\n** Compaction Stats [%s] **\n", cf_name.c_str());
-  written_size = std::min(written_size, static_cast<int>(len));
+  oss << "\n** Compaction Stats [" << cf_name.c_str() << "] **\n";
+
   auto hdr = [](LevelStatType t) {
     return InternalStats::compaction_level_stats.at(t).header_name.c_str();
   };
-  int line_size = snprintf(
-      buf + written_size, len - written_size,
-      "%s    %s   %s     %s %s  %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s "
-      "%s\n",
-      // Note that we skip COMPACTED_FILES and merge it with Files column
-      group_by.c_str(), hdr(LevelStatType::NUM_FILES),
-      hdr(LevelStatType::SIZE_BYTES), hdr(LevelStatType::SCORE),
-      hdr(LevelStatType::READ_GB), hdr(LevelStatType::RN_GB),
-      hdr(LevelStatType::RNP1_GB), hdr(LevelStatType::WRITE_GB),
-      hdr(LevelStatType::W_NEW_GB), hdr(LevelStatType::MOVED_GB),
-      hdr(LevelStatType::WRITE_AMP), hdr(LevelStatType::READ_MBPS),
-      hdr(LevelStatType::WRITE_MBPS), hdr(LevelStatType::COMP_SEC),
-      hdr(LevelStatType::COMP_CPU_SEC), hdr(LevelStatType::COMP_COUNT),
-      hdr(LevelStatType::AVG_SEC), hdr(LevelStatType::KEY_IN),
-      hdr(LevelStatType::KEY_DROP), hdr(LevelStatType::R_BLOB_GB),
-      hdr(LevelStatType::W_BLOB_GB));
 
-  written_size += line_size;
-  written_size = std::min(written_size, static_cast<int>(len));
-  snprintf(buf + written_size, len - written_size, "%s\n",
-           std::string(line_size, '-').c_str());
+  // Note that we skip COMPACTED_FILES and merge it with Files column
+  oss << group_by.c_str() << "    "
+      << hdr(LevelStatType::NUM_FILES) << "   "
+      << hdr(LevelStatType::SIZE_BYTES) << "     "
+      << hdr(LevelStatType::SCORE) << " "
+      << hdr(LevelStatType::READ_GB) << "  "
+      << hdr(LevelStatType::RN_GB) << " "
+      << hdr(LevelStatType::RNP1_GB) << " "
+      << hdr(LevelStatType::WRITE_GB) << " "
+      << hdr(LevelStatType::W_NEW_GB) << " "
+      << hdr(LevelStatType::MOVED_GB) << " "
+      << hdr(LevelStatType::WRITE_AMP) << " "
+      << hdr(LevelStatType::READ_MBPS) << " "
+      << hdr(LevelStatType::WRITE_MBPS) << " "
+      << hdr(LevelStatType::COMP_SEC) << " "
+      << hdr(LevelStatType::COMP_CPU_SEC) << " "
+      << hdr(LevelStatType::COMP_COUNT) << " "
+      << hdr(LevelStatType::AVG_SEC) << " "
+      << hdr(LevelStatType::KEY_IN) << " "
+      << hdr(LevelStatType::KEY_DROP) << " "
+      << hdr(LevelStatType::R_BLOB_GB) << " "
+      << hdr(LevelStatType::W_BLOB_GB) << "\n";
+
+  // NOTE:
+  //
+  // Please make sure to return string stream config to the upstream caller
+  // in exact same condition you obtained it. Especially if you're overriding
+  // width, precision or notation of the underlying oss stream.
+  //
+  // Check PrintLevelStats for reference.
 }
 
 void PrepareLevelStats(std::map<LevelStatType, double>* level_stats,
@@ -158,68 +168,93 @@ void PrepareLevelStats(std::map<LevelStatType, double>* level_stats,
   (*level_stats)[LevelStatType::W_BLOB_GB] = stats.bytes_written_blob / kGB;
 }
 
-void PrintLevelStats(char* buf, size_t len, const std::string& name,
+void PrintLevelStats(std::ostringstream& oss, const std::string& name,
                      const std::map<LevelStatType, double>& stat_value) {
-  snprintf(
-      buf, len,
-      "%4s "      /*  Level */
-      "%6d/%-3d " /*  Files */
-      "%8s "      /*  Size */
-      "%5.1f "    /*  Score */
-      "%8.1f "    /*  Read(GB) */
-      "%7.1f "    /*  Rn(GB) */
-      "%8.1f "    /*  Rnp1(GB) */
-      "%9.1f "    /*  Write(GB) */
-      "%8.1f "    /*  Wnew(GB) */
-      "%9.1f "    /*  Moved(GB) */
-      "%5.1f "    /*  W-Amp */
-      "%8.1f "    /*  Rd(MB/s) */
-      "%8.1f "    /*  Wr(MB/s) */
-      "%9.2f "    /*  Comp(sec) */
-      "%17.2f "   /*  CompMergeCPU(sec) */
-      "%9d "      /*  Comp(cnt) */
-      "%8.3f "    /*  Avg(sec) */
-      "%7s "      /*  KeyIn */
-      "%6s "      /*  KeyDrop */
-      "%9.1f "    /*  Rblob(GB) */
-      "%9.1f\n",  /*  Wblob(GB) */
-      name.c_str(), static_cast<int>(stat_value.at(LevelStatType::NUM_FILES)),
-      static_cast<int>(stat_value.at(LevelStatType::COMPACTED_FILES)),
-      BytesToHumanString(
+  int original_precision = oss.precision();
+  int original_width = oss.width();
+  std::ios_base::fmtflags original_flags = oss.flags();
+
+  oss << std::fixed
+      // Level
+      << std::setw(4) << name.c_str() << " "
+      // Files
+      << std::setw(6)
+      << static_cast<int>(stat_value.at(LevelStatType::NUM_FILES))
+      << "/"
+      << std::setw(3) << std::left
+      << static_cast<int>(stat_value.at(LevelStatType::COMPACTED_FILES))
+      << " " << std::right
+      // Size
+      << std::setw(8)
+      << BytesToHumanString(
           static_cast<uint64_t>(stat_value.at(LevelStatType::SIZE_BYTES)))
-          .c_str(),
-      stat_value.at(LevelStatType::SCORE),
-      stat_value.at(LevelStatType::READ_GB),
-      stat_value.at(LevelStatType::RN_GB),
-      stat_value.at(LevelStatType::RNP1_GB),
-      stat_value.at(LevelStatType::WRITE_GB),
-      stat_value.at(LevelStatType::W_NEW_GB),
-      stat_value.at(LevelStatType::MOVED_GB),
-      stat_value.at(LevelStatType::WRITE_AMP),
-      stat_value.at(LevelStatType::READ_MBPS),
-      stat_value.at(LevelStatType::WRITE_MBPS),
-      stat_value.at(LevelStatType::COMP_SEC),
-      stat_value.at(LevelStatType::COMP_CPU_SEC),
-      static_cast<int>(stat_value.at(LevelStatType::COMP_COUNT)),
-      stat_value.at(LevelStatType::AVG_SEC),
-      NumberToHumanString(
+          .c_str()
+      << " "
+      // Score
+      << std::setprecision(1)
+      << std::setw(5) << stat_value.at(LevelStatType::SCORE) << " "
+      // Read(GB)
+      << std::setw(8) << stat_value.at(LevelStatType::READ_GB) << " "
+      // Rn(GB)
+      << std::setw(7) << stat_value.at(LevelStatType::RN_GB) << " "
+      // Rnp1(GB)
+      << std::setw(8) << stat_value.at(LevelStatType::RNP1_GB) << " "
+      // Write(GB)
+      << std::setw(9) << stat_value.at(LevelStatType::WRITE_GB) << " "
+      // Wnew(GB)
+      << std::setw(8) << stat_value.at(LevelStatType::W_NEW_GB) << " "
+      // Moved(GB)
+      << std::setw(9) << stat_value.at(LevelStatType::MOVED_GB) << " "
+      // W-Amp
+      << std::setw(5) << stat_value.at(LevelStatType::WRITE_AMP) << " "
+      // Rd(MB/s)
+      << std::setw(8) << stat_value.at(LevelStatType::READ_MBPS) << " "
+      // Wr(MB/s)
+      << std::setw(8) << stat_value.at(LevelStatType::WRITE_MBPS) << " "
+      // Comp(sec)
+      << std::setprecision(2)
+      << std::setw(9) << stat_value.at(LevelStatType::COMP_SEC) << " "
+      // CompMergeCPU(sec)
+      << std::setw(17) << stat_value.at(LevelStatType::COMP_CPU_SEC) << " "
+      // Comp(cnt)
+      << std::setw(9)
+      << static_cast<int>(stat_value.at(LevelStatType::COMP_COUNT)) << " "
+      // Avg(sec)
+      << std::setw(8)
+      << std::setprecision(3) << stat_value.at(LevelStatType::AVG_SEC) << " "
+      // KeyIn
+      << std::setw(7)
+      << NumberToHumanString(
           static_cast<std::int64_t>(stat_value.at(LevelStatType::KEY_IN)))
-          .c_str(),
-      NumberToHumanString(
+          .c_str()
+      // KeyDrop
+      << " "
+      << std::setw(6)
+      << NumberToHumanString(
           static_cast<std::int64_t>(stat_value.at(LevelStatType::KEY_DROP)))
-          .c_str(),
-      stat_value.at(LevelStatType::R_BLOB_GB),
-      stat_value.at(LevelStatType::W_BLOB_GB));
+          .c_str()
+      << " "
+      // Rblob(GB)
+      << std::setprecision(1)
+      << std::setw(9)
+      << stat_value.at(LevelStatType::R_BLOB_GB)
+      // Wblob(GB)
+      << stat_value.at(LevelStatType::W_BLOB_GB)
+      << "\n";
+
+  // Restore original string stream configuration.
+  oss << std::setw(original_width) << std::setprecision(original_precision);
+  oss.flags(original_flags);
 }
 
-void PrintLevelStats(char* buf, size_t len, const std::string& name,
+void PrintLevelStats(std::ostringstream& oss, const std::string& name,
                      int num_files, int being_compacted, double total_file_size,
                      double score, double w_amp,
                      const InternalStats::CompactionStats& stats) {
   std::map<LevelStatType, double> level_stats;
   PrepareLevelStats(&level_stats, num_files, being_compacted, total_file_size,
                     score, w_amp, stats);
-  PrintLevelStats(buf, len, name, level_stats);
+  PrintLevelStats(oss, name, level_stats);
 }
 
 // Assumes that trailing numbers represent an optional argument. This requires
@@ -1008,10 +1043,9 @@ bool InternalStats::HandleNumFilesAtLevel(std::string* value, Slice suffix) {
   if (!ok || static_cast<int>(level) >= number_levels_) {
     return false;
   } else {
-    char buf[100];
-    snprintf(buf, sizeof(buf), "%d",
-             vstorage->NumLevelFiles(static_cast<int>(level)));
-    *value = buf;
+    std::string num_files(
+      std::to_string(vstorage->NumLevelFiles(static_cast<int>(level))));
+    *value = num_files;
     return true;
   }
 }
@@ -1030,19 +1064,18 @@ bool InternalStats::HandleCompressionRatioAtLevelPrefix(std::string* value,
 }
 
 bool InternalStats::HandleLevelStats(std::string* value, Slice /*suffix*/) {
-  char buf[1000];
   const auto* vstorage = cfd_->current()->storage_info();
-  snprintf(buf, sizeof(buf),
-           "Level Files Size(MB)\n"
-           "--------------------\n");
-  value->append(buf);
+  std::ostringstream stats;
+  stats << "Level Files Size(MB)\n"
+        << "--------------------\n";
 
+  stats << std::fixed << std::setprecision(0);
   for (int level = 0; level < number_levels_; level++) {
-    snprintf(buf, sizeof(buf), "%3d %8d %8.0f\n", level,
-             vstorage->NumLevelFiles(level),
-             vstorage->NumLevelBytes(level) / kMB);
-    value->append(buf);
+    stats << std::setw(3) << level << " "
+          << std::setw(8) << vstorage->NumLevelFiles(level) << " "
+          << vstorage->NumLevelBytes(level) / kMB << "\n";
   }
+  value->append(stats.str());
   return true;
 }
 
@@ -1544,14 +1577,18 @@ void InternalStats::DumpDBMapStats(
 }
 
 void InternalStats::DumpDBStats(std::string* value) {
-  char buf[1000];
+  std::ostringstream stats;
+  stats << std::fixed;
+
   // DB-level stats, only available from default column family
   double seconds_up = (clock_->NowMicros() - started_at_) / kMicrosInSec;
   double interval_seconds_up = seconds_up - db_stats_snapshot_.seconds_up;
-  snprintf(buf, sizeof(buf),
-           "\n** DB Stats **\nUptime(secs): %.1f total, %.1f interval\n",
-           seconds_up, interval_seconds_up);
-  value->append(buf);
+
+  stats << "\n** DB Stats **\nUptime(secs): "
+        << std::setprecision(1)
+        << seconds_up << " total, "
+        << interval_seconds_up << " interval\n";
+
   // Cumulative
   uint64_t user_bytes_written =
       GetDBStats(InternalStats::kIntStatsBytesWritten);
@@ -1577,77 +1614,92 @@ void InternalStats::DumpDBStats(std::string* value) {
   // writes/groups is the average group commit size.
   //
   // The format is the same for interval stats.
-  snprintf(buf, sizeof(buf),
-           "Cumulative writes: %s writes, %s keys, %s commit groups, "
-           "%.1f writes per commit group, ingest: %.2f GB, %.2f MB/s\n",
-           NumberToHumanString(write_other + write_self).c_str(),
-           NumberToHumanString(num_keys_written).c_str(),
-           NumberToHumanString(write_self).c_str(),
-           (write_other + write_self) /
-               std::max(1.0, static_cast<double>(write_self)),
-           user_bytes_written / kGB,
-           user_bytes_written / kMB / std::max(seconds_up, 0.001));
-  value->append(buf);
+  stats << "Cumulative writes: "
+        << NumberToHumanString(write_other + write_self).c_str() << " writes, "
+        << NumberToHumanString(num_keys_written).c_str() << " keys, "
+        << NumberToHumanString(write_self).c_str() << " commit groups, ";
+
+  stats << std::setprecision(1)
+        << (write_other + write_self) /
+          std::max(1.0, static_cast<double>(write_self))
+        << " writes per commit group,"
+        << " ingest: "
+        << std::setprecision(2)
+        << user_bytes_written / kGB << " GB, "
+        << user_bytes_written / kMB / std::max(seconds_up, 0.001) << " MB/s\n";
+
   // WAL
-  snprintf(buf, sizeof(buf),
-           "Cumulative WAL: %s writes, %s syncs, "
-           "%.2f writes per sync, written: %.2f GB, %.2f MB/s\n",
-           NumberToHumanString(write_with_wal).c_str(),
-           NumberToHumanString(wal_synced).c_str(),
-           write_with_wal / std::max(1.0, static_cast<double>(wal_synced)),
-           wal_bytes / kGB, wal_bytes / kMB / std::max(seconds_up, 0.001));
-  value->append(buf);
+  stats << "Cumulative WAL: "
+        << NumberToHumanString(write_with_wal).c_str() << " writes, "
+        << NumberToHumanString(wal_synced).c_str() << " syncs, "
+        << std::setprecision(2)
+        << write_with_wal / std::max(1.0, static_cast<double>(wal_synced))
+        << " writes per sync,"
+        << " written: "
+        << wal_bytes / kGB << " GB, "
+        << wal_bytes / kMB / std::max(seconds_up, 0.001) << " MB/s\n";
+
   // Stall
   AppendHumanMicros(write_stall_micros, human_micros, kHumanMicrosLen, true);
-  snprintf(buf, sizeof(buf), "Cumulative stall: %s, %.1f percent\n",
-           human_micros,
-           // 10000 = divide by 1M to get secs, then multiply by 100 for pct
-           write_stall_micros / 10000.0 / std::max(seconds_up, 0.001));
-  value->append(buf);
+  stats << "Cumulative stall: " << human_micros << ", "
+        << std::setprecision(1)
+        // 10000 = divide by 1M to get secs, then multiply by 100 for pct
+        << write_stall_micros / 10000.0 / std::max(seconds_up, 0.001)
+        << " percent\n";
 
   // Interval
   uint64_t interval_write_other = write_other - db_stats_snapshot_.write_other;
   uint64_t interval_write_self = write_self - db_stats_snapshot_.write_self;
   uint64_t interval_num_keys_written =
       num_keys_written - db_stats_snapshot_.num_keys_written;
-  snprintf(
-      buf, sizeof(buf),
-      "Interval writes: %s writes, %s keys, %s commit groups, "
-      "%.1f writes per commit group, ingest: %.2f MB, %.2f MB/s\n",
-      NumberToHumanString(interval_write_other + interval_write_self).c_str(),
-      NumberToHumanString(interval_num_keys_written).c_str(),
-      NumberToHumanString(interval_write_self).c_str(),
-      static_cast<double>(interval_write_other + interval_write_self) /
-          std::max(1.0, static_cast<double>(interval_write_self)),
-      (user_bytes_written - db_stats_snapshot_.ingest_bytes) / kMB,
-      (user_bytes_written - db_stats_snapshot_.ingest_bytes) / kMB /
-          std::max(interval_seconds_up, 0.001)),
-      value->append(buf);
+
+  stats << "Interval writes: "
+        << NumberToHumanString(interval_write_other + interval_write_self)
+        << " writes, "
+        << NumberToHumanString(interval_num_keys_written).c_str()
+        << " keys, "
+        << NumberToHumanString(interval_write_self).c_str()
+        << " commit groups, "
+        << std::setprecision(1)
+        << static_cast<double>(interval_write_other + interval_write_self) /
+          std::max(1.0, static_cast<double>(interval_write_self))
+        << " writes per commit group,"
+        << " ingest: "
+        << std::setprecision(2)
+        << (user_bytes_written - db_stats_snapshot_.ingest_bytes) / kMB
+        << " MB, "
+        << (user_bytes_written - db_stats_snapshot_.ingest_bytes) / kMB /
+          std::max(interval_seconds_up, 0.001)
+        << " MB/s\n";
 
   uint64_t interval_write_with_wal =
       write_with_wal - db_stats_snapshot_.write_with_wal;
   uint64_t interval_wal_synced = wal_synced - db_stats_snapshot_.wal_synced;
   uint64_t interval_wal_bytes = wal_bytes - db_stats_snapshot_.wal_bytes;
 
-  snprintf(buf, sizeof(buf),
-           "Interval WAL: %s writes, %s syncs, "
-           "%.2f writes per sync, written: %.2f GB, %.2f MB/s\n",
-           NumberToHumanString(interval_write_with_wal).c_str(),
-           NumberToHumanString(interval_wal_synced).c_str(),
-           interval_write_with_wal /
-               std::max(1.0, static_cast<double>(interval_wal_synced)),
-           interval_wal_bytes / kGB,
-           interval_wal_bytes / kMB / std::max(interval_seconds_up, 0.001));
-  value->append(buf);
+  stats << "Interval WAL: "
+        << NumberToHumanString(interval_write_with_wal).c_str() << " writes, "
+        << NumberToHumanString(interval_wal_synced).c_str() << " syncs, "
+        << std::setprecision(2)
+        << interval_write_with_wal /
+          std::max(1.0, static_cast<double>(interval_wal_synced))
+        << " writes per sync,"
+        << " written:"
+        << interval_wal_bytes / kGB
+        << " MB, "
+        << interval_wal_bytes / kMB / std::max(interval_seconds_up, 0.001)
+        << " MB/s\n";
 
   // Stall
   AppendHumanMicros(write_stall_micros - db_stats_snapshot_.write_stall_micros,
                     human_micros, kHumanMicrosLen, true);
-  snprintf(buf, sizeof(buf), "Interval stall: %s, %.1f percent\n", human_micros,
-           // 10000 = divide by 1M to get secs, then multiply by 100 for pct
-           (write_stall_micros - db_stats_snapshot_.write_stall_micros) /
-               10000.0 / std::max(interval_seconds_up, 0.001));
-  value->append(buf);
+  stats << "Interval stall: " << human_micros << ", "
+        << std::setprecision(1)
+        << (write_stall_micros - db_stats_snapshot_.write_stall_micros) /
+               10000.0 / std::max(interval_seconds_up, 0.001)
+        << " percent\n";
+
+  value->append(stats.str());
 
   std::string write_stall_stats;
   DumpDBStatsWriteStall(&write_stall_stats);
@@ -1926,10 +1978,9 @@ void InternalStats::DumpCFStats(std::string* value) {
 
 void InternalStats::DumpCFStatsNoFileHistogram(bool is_periodic,
                                                std::string* value) {
-  char buf[2000];
   // Per-ColumnFamily stats
-  PrintLevelStatsHeader(buf, sizeof(buf), cfd_->GetName(), "Level");
-  value->append(buf);
+  std::ostringstream cf_stats;
+  PrintLevelStatsHeader(cf_stats, cfd_->GetName(), "Level");
 
   // Print stats for each level
   const VersionStorageInfo* vstorage = cfd_->current()->storage_info();
@@ -1938,15 +1989,12 @@ void InternalStats::DumpCFStatsNoFileHistogram(bool is_periodic,
   DumpCFMapStats(vstorage, &levels_stats, &compaction_stats_sum);
   for (int l = 0; l < number_levels_; ++l) {
     if (levels_stats.find(l) != levels_stats.end()) {
-      PrintLevelStats(buf, sizeof(buf), "L" + std::to_string(l),
-                      levels_stats[l]);
-      value->append(buf);
+      PrintLevelStats(cf_stats, "L" + std::to_string(l), levels_stats[l]);
     }
   }
 
   // Print sum of level stats
-  PrintLevelStats(buf, sizeof(buf), "Sum", levels_stats[-1]);
-  value->append(buf);
+  PrintLevelStats(cf_stats, "Sum", levels_stats[-1]);
 
   uint64_t flush_ingest = cf_stats_value_[BYTES_FLUSHED];
   uint64_t add_file_ingest = cf_stats_value_[BYTES_INGESTED_ADD_FILE];
@@ -1957,76 +2005,73 @@ void InternalStats::DumpCFStatsNoFileHistogram(bool is_periodic,
   // Interval summary
   uint64_t interval_flush_ingest =
       flush_ingest - cf_stats_snapshot_.ingest_bytes_flush;
-  uint64_t interval_add_file_inget =
+  uint64_t interval_add_file_ingest =
       add_file_ingest - cf_stats_snapshot_.ingest_bytes_addfile;
   uint64_t interval_ingest =
-      interval_flush_ingest + interval_add_file_inget + 1;
+      interval_flush_ingest + interval_add_file_ingest + 1;
   CompactionStats interval_stats(compaction_stats_sum);
   interval_stats.Subtract(cf_stats_snapshot_.comp_stats);
   double w_amp =
       (interval_stats.bytes_written + interval_stats.bytes_written_blob) /
       static_cast<double>(interval_ingest);
-  PrintLevelStats(buf, sizeof(buf), "Int", 0, 0, 0, 0, w_amp, interval_stats);
-  value->append(buf);
+  PrintLevelStats(cf_stats, "Int", 0, 0, 0, 0, w_amp, interval_stats);
 
-  PrintLevelStatsHeader(buf, sizeof(buf), cfd_->GetName(), "Priority");
-  value->append(buf);
+  PrintLevelStatsHeader(cf_stats, cfd_->GetName(), "Priority");
   std::map<int, std::map<LevelStatType, double>> priorities_stats;
   DumpCFMapStatsByPriority(&priorities_stats);
   for (size_t priority = 0; priority < comp_stats_by_pri_.size(); ++priority) {
     if (priorities_stats.find(static_cast<int>(priority)) !=
         priorities_stats.end()) {
       PrintLevelStats(
-          buf, sizeof(buf),
+          cf_stats,
           Env::PriorityToString(static_cast<Env::Priority>(priority)),
           priorities_stats[static_cast<int>(priority)]);
-      value->append(buf);
     }
   }
 
   const auto blob_st = vstorage->GetBlobStats();
 
-  snprintf(buf, sizeof(buf),
-           "\nBlob file count: %" ROCKSDB_PRIszt
-           ", total size: %.1f GB, garbage size: %.1f GB, space amp: %.1f\n\n",
-           vstorage->GetBlobFiles().size(), blob_st.total_file_size / kGB,
-           blob_st.total_garbage_size / kGB, blob_st.space_amp);
-  value->append(buf);
+  cf_stats << std::setprecision(1);
+  cf_stats << "\nBlob file count: " << vstorage->GetBlobFiles().size() << ", "
+           << "total size: "<< blob_st.total_file_size / kGB << " GB, "
+           << "garbage size: " << blob_st.total_garbage_size / kGB << " GB, "
+           << "space amp: " << blob_st.space_amp << "\n\n";
 
   uint64_t now_micros = clock_->NowMicros();
   double seconds_up = (now_micros - started_at_) / kMicrosInSec;
   double interval_seconds_up = seconds_up - cf_stats_snapshot_.seconds_up;
-  snprintf(buf, sizeof(buf), "Uptime(secs): %.1f total, %.1f interval\n",
-           seconds_up, interval_seconds_up);
-  value->append(buf);
-  snprintf(buf, sizeof(buf), "Flush(GB): cumulative %.3f, interval %.3f\n",
-           flush_ingest / kGB, interval_flush_ingest / kGB);
-  value->append(buf);
-  snprintf(buf, sizeof(buf), "AddFile(GB): cumulative %.3f, interval %.3f\n",
-           add_file_ingest / kGB, interval_add_file_inget / kGB);
-  value->append(buf);
+
+  cf_stats << "Uptime(secs): "
+           << seconds_up << " total, "
+           << interval_seconds_up << " interval\n";
+
+  cf_stats << std::setprecision(3);
+  cf_stats << "Flush(GB): "
+           << "cumulative " << flush_ingest / kGB << ", "
+           << "interval " << interval_flush_ingest / kGB << "\n";
+
+  cf_stats << "AddFile(GB): "
+           << "cumulative " << add_file_ingest / kGB << ", "
+           << "interval " << interval_add_file_ingest / kGB << "\n";
 
   uint64_t interval_ingest_files_addfile =
       ingest_files_addfile - cf_stats_snapshot_.ingest_files_addfile;
-  snprintf(buf, sizeof(buf),
-           "AddFile(Total Files): cumulative %" PRIu64 ", interval %" PRIu64
-           "\n",
-           ingest_files_addfile, interval_ingest_files_addfile);
-  value->append(buf);
+
+  cf_stats << "AddFile(Total Files): "
+           << "cumulative " << ingest_files_addfile << ", "
+           << "interval " << interval_ingest_files_addfile << "\n";
 
   uint64_t interval_ingest_l0_files_addfile =
       ingest_l0_files_addfile - cf_stats_snapshot_.ingest_l0_files_addfile;
-  snprintf(buf, sizeof(buf),
-           "AddFile(L0 Files): cumulative %" PRIu64 ", interval %" PRIu64 "\n",
-           ingest_l0_files_addfile, interval_ingest_l0_files_addfile);
-  value->append(buf);
+  cf_stats << "AddFile(L0 Files): "
+           << "cumulative " << ingest_l0_files_addfile << ", "
+           << "interval " << interval_ingest_l0_files_addfile << "\n";
 
   uint64_t interval_ingest_keys_addfile =
       ingest_keys_addfile - cf_stats_snapshot_.ingest_keys_addfile;
-  snprintf(buf, sizeof(buf),
-           "AddFile(Keys): cumulative %" PRIu64 ", interval %" PRIu64 "\n",
-           ingest_keys_addfile, interval_ingest_keys_addfile);
-  value->append(buf);
+  cf_stats << "AddFile(Keys): "
+           << "cumulative " << ingest_keys_addfile << ", "
+           << "interval " << interval_ingest_keys_addfile << "\n";
 
   // Compact
   uint64_t compact_bytes_read = 0;
@@ -2041,15 +2086,14 @@ void InternalStats::DumpCFStatsNoFileHistogram(bool is_periodic,
     compact_micros += comp_stats_[level].micros;
   }
 
-  snprintf(buf, sizeof(buf),
-           "Cumulative compaction: %.2f GB write, %.2f MB/s write, "
-           "%.2f GB read, %.2f MB/s read, %.1f seconds\n",
-           compact_bytes_write / kGB,
-           compact_bytes_write / kMB / std::max(seconds_up, 0.001),
-           compact_bytes_read / kGB,
-           compact_bytes_read / kMB / std::max(seconds_up, 0.001),
-           compact_micros / kMicrosInSec);
-  value->append(buf);
+  cf_stats << std::setprecision(2);
+  cf_stats << "Cumulative compaction: "
+           << compact_bytes_write / kGB << " GB write, "
+           << compact_bytes_write / kMB / std::max(seconds_up, 0.001) << "MB/s write, "
+           << compact_bytes_read / kGB << " GB read, "
+           << compact_bytes_read / kMB / std::max(seconds_up, 0.001) << " MB/s read, "
+           << std::setprecision(1)
+           << compact_micros / kMicrosInSec << " seconds\n";
 
   // Compaction interval
   uint64_t interval_compact_bytes_write =
@@ -2059,27 +2103,26 @@ void InternalStats::DumpCFStatsNoFileHistogram(bool is_periodic,
   uint64_t interval_compact_micros =
       compact_micros - cf_stats_snapshot_.compact_micros;
 
-  snprintf(
-      buf, sizeof(buf),
-      "Interval compaction: %.2f GB write, %.2f MB/s write, "
-      "%.2f GB read, %.2f MB/s read, %.1f seconds\n",
-      interval_compact_bytes_write / kGB,
-      interval_compact_bytes_write / kMB / std::max(interval_seconds_up, 0.001),
-      interval_compact_bytes_read / kGB,
-      interval_compact_bytes_read / kMB / std::max(interval_seconds_up, 0.001),
-      interval_compact_micros / kMicrosInSec);
-  value->append(buf);
+  cf_stats << std::setprecision(2);
+  cf_stats << "Interval compaction: "
+           << interval_compact_bytes_write / kGB << " GB write, "
+           << interval_compact_bytes_write / kMB /
+            std::max(interval_seconds_up, 0.001) << " MB/s write, "
+           << interval_compact_bytes_read / kGB  << " GB read, "
+           << interval_compact_bytes_read / kMB /
+            std::max(interval_seconds_up, 0.001) << " MB/s read, "
+           << std::setprecision(1)
+           << interval_compact_micros / kMicrosInSec << " seconds\n";
 
-  snprintf(buf, sizeof(buf),
-           "Estimated pending compaction bytes: %" PRIu64 "\n",
-           vstorage->estimated_compaction_needed_bytes());
-  value->append(buf);
+  cf_stats << "Estimated pending compaction bytes: "
+           << vstorage->estimated_compaction_needed_bytes();
 
   if (is_periodic) {
     cf_stats_snapshot_.compact_bytes_write = compact_bytes_write;
     cf_stats_snapshot_.compact_bytes_read = compact_bytes_read;
     cf_stats_snapshot_.compact_micros = compact_micros;
   }
+  value->append(cf_stats.str());
 
   std::string write_stall_stats;
   uint64_t total_stall_count;

--- a/db/log_reader.cc
+++ b/db/log_reader.cc
@@ -313,11 +313,10 @@ bool Reader::ReadRecord(Slice* record, std::string* scratch,
         break;
 
       default: {
-        char buf[40];
-        snprintf(buf, sizeof(buf), "unknown record type %u", record_type);
+        std::string reason = "unknown record type " + std::to_string(record_type);
         ReportCorruption(
             (fragment.size() + (in_fragmented_record ? scratch->size() : 0)),
-            buf);
+            reason.c_str());
         in_fragmented_record = false;
         scratch->clear();
         break;
@@ -781,12 +780,10 @@ bool FragmentBufferedReader::ReadRecord(Slice* record, std::string* scratch,
         break;
 
       default: {
-        char buf[40];
-        snprintf(buf, sizeof(buf), "unknown record type %u",
-                 fragment_type_or_err);
+        std::string reason = "unknown record type " + std::to_string(fragment_type_or_err);
         ReportCorruption(
             fragment.size() + (in_fragmented_record_ ? fragments_.size() : 0),
-            buf);
+            reason.c_str());
         in_fragmented_record_ = false;
         fragments_.clear();
         break;

--- a/db/transaction_log_impl.cc
+++ b/db/transaction_log_impl.cc
@@ -231,13 +231,14 @@ bool TransactionLogIteratorImpl::IsBatchExpected(
   assert(batch);
   SequenceNumber batchSeq = WriteBatchInternal::Sequence(batch);
   if (batchSeq != expected_seq) {
-    char buf[200];
-    snprintf(buf, sizeof(buf),
-             "Discontinuity in log records. Got seq=%" PRIu64
-             ", Expected seq=%" PRIu64 ", Last flushed seq=%" PRIu64
-             ".Log iterator will reseek the correct batch.",
-             batchSeq, expected_seq, versions_->LastSequence());
-    reporter_.Info(buf);
+    std::ostringstream oss;
+    oss << "Discontinuity in log records. "
+        << "Got seq=" << batchSeq << ", "
+        << "Expected seq=" << expected_seq << ", "
+        << "Last flushed seq=" << versions_->LastSequence() << ". "
+        << "Log iterator will reseek the correct batch.";
+
+    reporter_.Info(oss.str().c_str());
     return false;
   }
   return true;


### PR DESCRIPTION
Summary: This change aims at increasing general memory safety and/or providing more comprehensive (not artificially capped) logging in scope of selected `/db` files (`db_impl/db_impl.cc`, `dbformat.cc`, `internal_stats.cc`, `log_reader.cc` and `transaction_log_impl.cc`).

Test plan: Verify logging structure & formatting parity by manually running the `/db` related tests exercising respective code paths pre and post change.